### PR TITLE
Add DOI enrichment for isPartOf records

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1191,10 +1191,16 @@ class OmekaAPI:
 
         # Apply transformations
         transformations_applied = []
+        transformation_report: dict[str, Any] = {}
         if apply_all_transformations:
             # Apply comprehensive transformations (includes whitespace)
-            item_set, items, all_media = transform_item_set_data(
-                item_set, items, all_media, apply_all=True, upgrade_https=upgrade_https
+            item_set, items, all_media, transformation_report = transform_item_set_data(
+                item_set,
+                items,
+                all_media,
+                apply_all=True,
+                upgrade_https=upgrade_https,
+                return_report=True,
             )
             transformations_applied.extend(
                 [
@@ -1209,12 +1215,19 @@ class OmekaAPI:
             if upgrade_https:
                 transformations_applied.append("http_to_https_upgrade")
             transformations_applied.append("url_normalization")
+            transformations_applied.append("doi_is_part_of_enrichment")
         elif apply_whitespace_normalization:
             # Apply only whitespace normalization
-            item_set, items, all_media = transform_item_set_data(
-                item_set, items, all_media, apply_all=False, upgrade_https=False
+            item_set, items, all_media, transformation_report = transform_item_set_data(
+                item_set,
+                items,
+                all_media,
+                apply_all=False,
+                upgrade_https=False,
+                return_report=True,
             )
             transformations_applied.append("whitespace_normalization")
+            transformations_applied.append("doi_is_part_of_enrichment")
 
         # Determine output directory
         if output_dir is None:
@@ -1251,6 +1264,7 @@ class OmekaAPI:
             "items_count": len(items),
             "media_count": len(all_media),
             "transformations_applied": transformations_applied,
+            "transformation_report": transformation_report,
             "files": {
                 "item_set": str(out_item_set_file.relative_to(output_path)),
                 "items": str(out_items_file.relative_to(output_path)),
@@ -1264,6 +1278,7 @@ class OmekaAPI:
             "items_transformed": len(items),
             "media_transformed": len(all_media),
             "transformations_applied": transformations_applied,
+            "transformation_report": transformation_report,
             "saved_to": {
                 "directory": transform_dir,
                 "item_set": out_item_set_file if item_set else None,

--- a/src/transformations.py
+++ b/src/transformations.py
@@ -8,9 +8,60 @@ import asyncio
 import html
 import re
 import unicodedata
+from difflib import SequenceMatcher
 from typing import Any
 
 import httpx
+
+BOOK_DOI_METADATA: tuple[dict[str, str], ...] = (
+    {
+        "DOI": "10.21255/SGB-01-406352",
+        "id": "https://doi.org/10.21255/sgb-01-406352",
+        "title": "Auf dem langen Weg zur Stadt. 50 000 v. Chr. – 800 n. Chr.",
+    },
+    {
+        "DOI": "10.21255/SGB-02-404936",
+        "id": "https://doi.org/10.21255/sgb-02-404936",
+        "title": "Eine Bischofsstadt zwischen Oberrhein und Jura. 800 – 1273",
+    },
+    {
+        "DOI": "10.21255/SGB-03-345800",
+        "id": "https://doi.org/10.21255/sgb-03-345800",
+        "title": "Stadt in Verhandlung. 1250 – 1530",
+    },
+    {
+        "DOI": "10.21255/SGB-04-283636",
+        "id": "https://doi.org/10.21255/sgb-04-283636",
+        "title": "Aufbrüche, Krisen, Transformationen. 1510 – 1790",
+    },
+    {
+        "DOI": "10.21255/SGB-05-155353",
+        "id": "https://doi.org/10.21255/sgb-05-155353",
+        "title": "Hinter der Mauer, vor der Moderne. 1760 – 1859",
+    },
+    {
+        "DOI": "10.21255/SGB-06-810743",
+        "id": "https://doi.org/10.21255/sgb-06-810743",
+        "title": "Die beschleunigte Stadt. 1856 – 1914",
+    },
+    {
+        "DOI": "10.21255/SGB-07-663402",
+        "id": "https://doi.org/10.21255/sgb-07-663402",
+        "title": "Stadt an der Grenze in einer Zeit der Gefährdung. 1912 – 1966",
+    },
+    {
+        "DOI": "10.21255/SGB-08-796384",
+        "id": "https://doi.org/10.21255/sgb-08-796384",
+        "title": "Auf dem Weg ins Jetzt. Seit 1960",
+    },
+    {
+        "DOI": "10.21255/SGB-09-486500",
+        "id": "https://doi.org/10.21255/sgb-09-486500",
+        "title": "Stadträume. Offen und begrenzt, gestaltet und umkämpft",
+    },
+)
+
+DOI_MATCH_THRESHOLD = 0.86
 
 
 def normalize_whitespace(text: str) -> str:
@@ -490,6 +541,166 @@ def transform_item(
     return result
 
 
+def normalize_doi_match_text(text: str) -> str:
+    """Normalize text for fuzzy DOI title matching."""
+    if not text:
+        return ""
+
+    text = unicodedata.normalize("NFKC", text).lower()
+    text = text.replace("–", "-").replace("—", "-").replace("−", "-")
+    text = unicodedata.normalize("NFKD", text)
+    text = re.sub(r"[\u0300-\u036f]", "", text)
+    text = text.replace("chr.", "chr")
+    text = re.sub(r"\(hg[.,:]?\)|\bhg[.,:]?", " ", text)
+    text = re.sub(r"\bstadt\.?geschichte\.?basel\b", " ", text)
+    text = re.sub(r"\bbasel\b|\bbd\.?\b|\bband\b", " ", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _partial_ratio(needle: str, haystack: str) -> float:
+    """Return a difflib-based partial match ratio without external dependencies."""
+    if not needle or not haystack:
+        return 0.0
+    if len(needle) > len(haystack):
+        needle, haystack = haystack, needle
+    if needle in haystack:
+        return 1.0
+
+    window = len(needle)
+    best = 0.0
+    for index in range(0, max(len(haystack) - window + 1, 1)):
+        score = SequenceMatcher(None, needle, haystack[index : index + window]).ratio()
+        if score > best:
+            best = score
+    return best
+
+
+def _literal_is_part_of_values(item_data: dict[str, Any]) -> list[str]:
+    values = []
+    for prop in item_data.get("dcterms:isPartOf") or []:
+        if isinstance(prop, dict) and prop.get("type") == "literal":
+            value = prop.get("@value")
+            if isinstance(value, str) and value.strip():
+                values.append(value)
+    return values
+
+
+def _abb_identifiers(item_data: dict[str, Any]) -> list[str]:
+    identifiers = []
+    for prop in item_data.get("dcterms:identifier") or []:
+        if not isinstance(prop, dict):
+            continue
+        value = prop.get("@value")
+        if isinstance(value, str) and re.fullmatch(r"abb\d+", value.strip(), re.I):
+            identifiers.append(value.strip())
+    return identifiers
+
+
+def _doi_uri_exists(is_part_of: list[Any], doi_uri: str) -> bool:
+    doi_uri = doi_uri.lower()
+    return any(
+        isinstance(prop, dict) and str(prop.get("@id", "")).lower() == doi_uri
+        for prop in is_part_of
+    )
+
+
+def _best_book_doi_match(
+    is_part_of_literals: list[str],
+) -> tuple[dict[str, str], float] | None:
+    text = normalize_doi_match_text(" ".join(is_part_of_literals))
+    if not text:
+        return None
+
+    best: tuple[dict[str, str], float] | None = None
+    for metadata in BOOK_DOI_METADATA:
+        title = normalize_doi_match_text(metadata["title"])
+        score = _partial_ratio(title, text)
+        if score >= DOI_MATCH_THRESHOLD and (best is None or score > best[1]):
+            best = (metadata, score)
+    return best
+
+
+def enrich_item_with_book_doi(
+    item_data: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
+    """Append a book DOI URI to dcterms:isPartOf using existing literals only.
+
+    Returns (item, enrichment_report, missing_report). ABB items without a usable
+    literal dcterms:isPartOf value are reported for manual review.
+    """
+    if not isinstance(item_data, dict):
+        return item_data, None, None
+
+    is_part_of_literals = _literal_is_part_of_values(item_data)
+    abb_identifiers = _abb_identifiers(item_data)
+
+    if not is_part_of_literals:
+        if abb_identifiers:
+            return item_data, None, {
+                "item_id": item_data.get("o:id"),
+                "title": item_data.get("o:title"),
+                "identifiers": abb_identifiers,
+                "reason": "missing_literal_dcterms_isPartOf",
+            }
+        return item_data, None, None
+
+    match = _best_book_doi_match(is_part_of_literals)
+    if match is None:
+        return item_data, None, None
+
+    metadata, score = match
+    is_part_of = list(item_data.get("dcterms:isPartOf") or [])
+    if _doi_uri_exists(is_part_of, metadata["id"]):
+        return item_data, None, None
+
+    result = item_data.copy()
+    result["dcterms:isPartOf"] = [
+        *is_part_of,
+        {
+            "type": "uri",
+            "property_id": 33,
+            "property_label": "Is Part Of",
+            "is_public": True,
+            "@id": metadata["id"],
+            "o:label": metadata["title"],
+        },
+    ]
+
+    return result, {
+        "item_id": item_data.get("o:id"),
+        "title": item_data.get("o:title"),
+        "doi": metadata["DOI"],
+        "doi_uri": metadata["id"],
+        "doi_title": metadata["title"],
+        "match_score": round(score, 3),
+    }, None
+
+
+def enrich_items_with_book_dois(
+    items: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Enrich items with book DOI URI values and collect a metadata report."""
+    enriched_items = []
+    enriched_report = []
+    missing_is_part_of = []
+
+    for item in items:
+        enriched_item, report_entry, missing_entry = enrich_item_with_book_doi(item)
+        enriched_items.append(enriched_item)
+        if report_entry:
+            enriched_report.append(report_entry)
+        if missing_entry:
+            missing_is_part_of.append(missing_entry)
+
+    return enriched_items, {
+        "book_dois_considered": len(BOOK_DOI_METADATA),
+        "items_enriched": len(enriched_report),
+        "enriched_items": enriched_report,
+        "abb_items_missing_is_part_of": missing_is_part_of,
+    }
+
+
 def transform_media(
     media_data: dict[str, Any], apply_all: bool = False, upgrade_https: bool = True
 ) -> dict[str, Any]:
@@ -522,7 +733,11 @@ def transform_item_set_data(
     media: list[dict[str, Any]],
     apply_all: bool = False,
     upgrade_https: bool = True,
-) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    return_report: bool = False,
+) -> (
+    tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]
+    | tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]
+):
     """Transform an entire item set with all its items and media.
 
     This function:
@@ -536,9 +751,11 @@ def transform_item_set_data(
         media: List of media data dictionaries
         apply_all: If True, apply all transformations; if False, only whitespace
         upgrade_https: If True, upgrade HTTP URLs to HTTPS where available
+        return_report: If True, include a DOI enrichment report in the return value
 
     Returns:
-        Tuple of (transformed_item_set, transformed_items, transformed_media)
+        Tuple of (transformed_item_set, transformed_items, transformed_media),
+        plus a report dictionary if return_report=True.
     """
     # Transform the item set itself (though it usually doesn't have much text)
     transformed_item_set = transform_item(
@@ -551,6 +768,9 @@ def transform_item_set_data(
         for item in items
     ]
 
+    # Enrich item-level isPartOf citations with book DOI URI values.
+    transformed_items, doi_report = enrich_items_with_book_dois(transformed_items)
+
     # Transform all media (includes setting private flag for placeholders)
     transformed_media = [
         transform_media(m, apply_all=apply_all, upgrade_https=upgrade_https)
@@ -562,6 +782,11 @@ def transform_item_set_data(
     transformed_items = propagate_private_flag_to_items(
         transformed_items, transformed_media
     )
+
+    if return_report:
+        return transformed_item_set, transformed_items, transformed_media, {
+            "doi_is_part_of_enrichment": doi_report,
+        }
 
     return transformed_item_set, transformed_items, transformed_media
 

--- a/src/transformations.py
+++ b/src/transformations.py
@@ -559,11 +559,14 @@ def normalize_doi_match_text(text: str) -> str:
 
 
 def _partial_ratio(needle: str, haystack: str) -> float:
-    """Return a difflib-based partial match ratio without external dependencies."""
+    """Return how much of ``needle`` appears within ``haystack`` (difflib, no deps).
+
+    Directional on purpose: a ``haystack`` shorter than ``needle`` cannot contain it
+    and scores low. (Swapping the two would let a 2-char citation like "ch" match a
+    full book title at 1.0 — see the stadtgeschichtebasel.ch false positive.)
+    """
     if not needle or not haystack:
         return 0.0
-    if len(needle) > len(haystack):
-        needle, haystack = haystack, needle
     if needle in haystack:
         return 1.0
 
@@ -624,10 +627,12 @@ def _best_book_doi_match(
 def enrich_item_with_book_doi(
     item_data: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
-    """Append a book DOI URI to dcterms:isPartOf using existing literals only.
+    """Replace a literal dcterms:isPartOf citation with the matching book DOI URI.
 
-    Returns (item, enrichment_report, missing_report). ABB items without a usable
-    literal dcterms:isPartOf value are reported for manual review.
+    Matching uses only existing isPartOf literals; on a confident match the literal
+    value(s) are replaced by a canonical DOI URI (non-literal values are kept), so
+    isPartOf is uniform per volume. Returns (item, enrichment_report, missing_report);
+    ABB items without a usable literal dcterms:isPartOf value are reported for review.
     """
     if not isinstance(item_data, dict):
         return item_data, None, None
@@ -654,9 +659,17 @@ def enrich_item_with_book_doi(
     if _doi_uri_exists(is_part_of, metadata["id"]):
         return item_data, None, None
 
+    # Replace the (inconsistent) citation literal(s) with the canonical DOI URI so
+    # isPartOf is uniform per volume. Non-literal values are preserved.
+    # ponytail: assumes one citation literal per item (true in current data).
+    kept = [
+        prop
+        for prop in is_part_of
+        if not (isinstance(prop, dict) and prop.get("type") == "literal")
+    ]
     result = item_data.copy()
     result["dcterms:isPartOf"] = [
-        *is_part_of,
+        *kept,
         {
             "type": "uri",
             "property_id": 33,

--- a/test/test_transformations.py
+++ b/test/test_transformations.py
@@ -283,8 +283,8 @@ def test_book_doi_metadata_excludes_chapters() -> None:
     )
 
 
-def test_enrich_item_with_book_doi_appends_uri_from_is_part_of_literal() -> None:
-    """Test fuzzy matching against existing dcterms:isPartOf literals only."""
+def test_enrich_item_with_book_doi_replaces_literal_with_uri() -> None:
+    """The inconsistent citation literal is replaced by the canonical DOI URI."""
     item = {
         "o:id": 1,
         "o:title": "Some unrelated image title",
@@ -305,16 +305,37 @@ def test_enrich_item_with_book_doi_appends_uri_from_is_part_of_literal() -> None
     assert missing is None
     assert report is not None
     assert report["doi"] == "10.21255/SGB-04-283636"
-    assert len(result["dcterms:isPartOf"]) == 2
-    assert result["dcterms:isPartOf"][0]["type"] == "literal"
-    assert result["dcterms:isPartOf"][1] == {
-        "type": "uri",
-        "property_id": 33,
-        "property_label": "Is Part Of",
-        "is_public": True,
-        "@id": "https://doi.org/10.21255/sgb-04-283636",
-        "o:label": "Aufbrüche, Krisen, Transformationen. 1510 – 1790",
+    # literal dropped, only the canonical DOI URI remains
+    assert result["dcterms:isPartOf"] == [
+        {
+            "type": "uri",
+            "property_id": 33,
+            "property_label": "Is Part Of",
+            "is_public": True,
+            "@id": "https://doi.org/10.21255/sgb-04-283636",
+            "o:label": "Aufbrüche, Krisen, Transformationen. 1510 – 1790",
+        }
+    ]
+
+
+def test_enrich_item_with_book_doi_ignores_non_citation_literal() -> None:
+    """Junk isPartOf like 'stadtgeschichtebasel.ch' must not match a volume.
+
+    Regression: it normalizes to 'ch', which used to score 1.0 against Band 1.
+    """
+    item = {
+        "o:id": 12856,
+        "o:title": "Data Story: Schulden einer Stadt",
+        "dcterms:isPartOf": [
+            {"type": "literal", "property_id": 33, "@value": "stadtgeschichtebasel.ch"}
+        ],
     }
+
+    result, report, missing = enrich_item_with_book_doi(item)
+
+    assert report is None
+    assert missing is None
+    assert result == item  # untouched, literal preserved
 
 
 def test_enrich_item_with_book_doi_is_idempotent() -> None:
@@ -392,7 +413,8 @@ def test_enrich_items_with_book_dois_report_counts() -> None:
 
     result, report = enrich_items_with_book_dois(items)
 
-    assert len(result[0]["dcterms:isPartOf"]) == 2
+    assert len(result[0]["dcterms:isPartOf"]) == 1
+    assert result[0]["dcterms:isPartOf"][0]["type"] == "uri"
     assert report["book_dois_considered"] == 9
     assert report["items_enriched"] == 1
     assert len(report["enriched_items"]) == 1
@@ -418,7 +440,7 @@ def test_transform_item_set_data_can_return_doi_report() -> None:
     )
 
     doi_report = report["doi_is_part_of_enrichment"]
-    assert transformed_items[0]["dcterms:isPartOf"][1]["@id"] == "https://doi.org/10.21255/sgb-08-796384"
+    assert transformed_items[0]["dcterms:isPartOf"][0]["@id"] == "https://doi.org/10.21255/sgb-08-796384"
     assert doi_report["items_enriched"] == 1
     assert doi_report["enriched_items"][0]["doi"] == "10.21255/SGB-08-796384"
 
@@ -435,7 +457,8 @@ if __name__ == "__main__":
     test_transform_media()
     test_real_world_examples()
     test_book_doi_metadata_excludes_chapters()
-    test_enrich_item_with_book_doi_appends_uri_from_is_part_of_literal()
+    test_enrich_item_with_book_doi_replaces_literal_with_uri()
+    test_enrich_item_with_book_doi_ignores_non_citation_literal()
     test_enrich_item_with_book_doi_is_idempotent()
     test_enrich_item_reports_abb_missing_is_part_of_literal()
     test_enrich_items_with_book_dois_report_counts()

--- a/test/test_transformations.py
+++ b/test/test_transformations.py
@@ -1,8 +1,12 @@
 """Tests for data transformation utilities."""
 
 from src.transformations import (
+    BOOK_DOI_METADATA,
+    enrich_item_with_book_doi,
+    enrich_items_with_book_dois,
     normalize_whitespace,
     transform_item,
+    transform_item_set_data,
     transform_media,
     transform_property_value,
 )
@@ -270,6 +274,155 @@ def test_real_world_examples() -> None:
     print("  ✓ Multiple line breaks normalized")
 
 
+def test_book_doi_metadata_excludes_chapters() -> None:
+    """Test DOI enrichment only considers book-level DOIs."""
+    assert len(BOOK_DOI_METADATA) == 9
+    assert all(
+        "." not in metadata["DOI"].lower().split("/sgb-", 1)[1]
+        for metadata in BOOK_DOI_METADATA
+    )
+
+
+def test_enrich_item_with_book_doi_appends_uri_from_is_part_of_literal() -> None:
+    """Test fuzzy matching against existing dcterms:isPartOf literals only."""
+    item = {
+        "o:id": 1,
+        "o:title": "Some unrelated image title",
+        "dcterms:identifier": [{"type": "literal", "@value": "abb12345"}],
+        "dcterms:isPartOf": [
+            {
+                "type": "literal",
+                "property_id": 33,
+                "property_label": "Is Part Of",
+                "is_public": True,
+                "@value": "Burghartz, Susanna (Hg,): Aufbrüche, Krisen, Transformationen. 1510-1790, Basel 2024 (Stadt.Geschichte.Basel 4).",
+            }
+        ],
+    }
+
+    result, report, missing = enrich_item_with_book_doi(item)
+
+    assert missing is None
+    assert report is not None
+    assert report["doi"] == "10.21255/SGB-04-283636"
+    assert len(result["dcterms:isPartOf"]) == 2
+    assert result["dcterms:isPartOf"][0]["type"] == "literal"
+    assert result["dcterms:isPartOf"][1] == {
+        "type": "uri",
+        "property_id": 33,
+        "property_label": "Is Part Of",
+        "is_public": True,
+        "@id": "https://doi.org/10.21255/sgb-04-283636",
+        "o:label": "Aufbrüche, Krisen, Transformationen. 1510 – 1790",
+    }
+
+
+def test_enrich_item_with_book_doi_is_idempotent() -> None:
+    """Test an existing DOI URI is not appended again."""
+    item = {
+        "o:id": 1,
+        "dcterms:isPartOf": [
+            {
+                "type": "literal",
+                "property_id": 33,
+                "property_label": "Is Part Of",
+                "is_public": True,
+                "@value": "Stadt in Verhandlung. 1250-1530. Basel 2024 (Stadt.Geschichte.Basel 3).",
+            },
+            {
+                "type": "uri",
+                "property_id": 33,
+                "property_label": "Is Part Of",
+                "is_public": True,
+                "@id": "https://doi.org/10.21255/sgb-03-345800",
+                "o:label": "Stadt in Verhandlung. 1250 – 1530",
+            },
+        ],
+    }
+
+    result, report, missing = enrich_item_with_book_doi(item)
+
+    assert result == item
+    assert report is None
+    assert missing is None
+
+
+def test_enrich_item_reports_abb_missing_is_part_of_literal() -> None:
+    """Test ABB records without usable dcterms:isPartOf literals are reported."""
+    item = {
+        "o:id": 7,
+        "o:title": "Needs review",
+        "dcterms:identifier": [{"type": "literal", "@value": "abb98765"}],
+    }
+
+    result, report, missing = enrich_item_with_book_doi(item)
+
+    assert result == item
+    assert report is None
+    assert missing == {
+        "item_id": 7,
+        "title": "Needs review",
+        "identifiers": ["abb98765"],
+        "reason": "missing_literal_dcterms_isPartOf",
+    }
+
+
+def test_enrich_items_with_book_dois_report_counts() -> None:
+    """Test batch enrichment returns counts and missing ABB entries."""
+    items = [
+        {
+            "o:id": 1,
+            "dcterms:isPartOf": [
+                {
+                    "type": "literal",
+                    "@value": "Die beschleunigte Stadt. 1856-1914, Basel 2024.",
+                }
+            ],
+        },
+        {
+            "o:id": 2,
+            "o:title": "Missing relation",
+            "dcterms:identifier": [{"type": "literal", "@value": "abb11111"}],
+        },
+        {
+            "o:id": 3,
+            "dcterms:identifier": [{"type": "literal", "@value": "obj11111"}],
+        },
+    ]
+
+    result, report = enrich_items_with_book_dois(items)
+
+    assert len(result[0]["dcterms:isPartOf"]) == 2
+    assert report["book_dois_considered"] == 9
+    assert report["items_enriched"] == 1
+    assert len(report["enriched_items"]) == 1
+    assert len(report["abb_items_missing_is_part_of"]) == 1
+    assert report["abb_items_missing_is_part_of"][0]["item_id"] == 2
+
+
+def test_transform_item_set_data_can_return_doi_report() -> None:
+    """Test end-to-end item set transformation includes the DOI report."""
+    item = {
+        "o:id": 1,
+        "o:title": "Test item",
+        "dcterms:isPartOf": [
+            {
+                "type": "literal",
+                "@value": "Auf dem Weg ins Jetzt. Seit 1960. Basel 2025 (Stadt.Geschichte.Basel 8).",
+            }
+        ],
+    }
+
+    _item_set, transformed_items, _media, report = transform_item_set_data(
+        {}, [item], [], return_report=True
+    )
+
+    doi_report = report["doi_is_part_of_enrichment"]
+    assert transformed_items[0]["dcterms:isPartOf"][1]["@id"] == "https://doi.org/10.21255/sgb-08-796384"
+    assert doi_report["items_enriched"] == 1
+    assert doi_report["enriched_items"][0]["doi"] == "10.21255/SGB-08-796384"
+
+
 if __name__ == "__main__":
     print("Testing data transformation utilities")
     print("=" * 60)
@@ -281,6 +434,12 @@ if __name__ == "__main__":
     test_transform_item()
     test_transform_media()
     test_real_world_examples()
+    test_book_doi_metadata_excludes_chapters()
+    test_enrich_item_with_book_doi_appends_uri_from_is_part_of_literal()
+    test_enrich_item_with_book_doi_is_idempotent()
+    test_enrich_item_reports_abb_missing_is_part_of_literal()
+    test_enrich_items_with_book_dois_report_counts()
+    test_transform_item_set_data_can_return_doi_report()
 
     print("\n" + "=" * 60)
     print("✓ All transformation tests passed!")


### PR DESCRIPTION
Closes #38\n\n## Summary\n- add book-level DOI enrichment for existing literal dcterms:isPartOf values\n- append DOI URI values without replacing existing citation literals\n- report ABB records missing usable dcterms:isPartOf literals in transformation metadata\n\n## Tests\n- uv run pytest test/test_transformations.py\n- uv run pytest\n- uv run ruff check src/transformations.py src/api.py test/test_transformations.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic DOI enrichment for applicable item records when matching source text is found.
  * Transformation runs can now return a detailed report alongside the processed data.

* **Bug Fixes**
  * Improved handling of whitespace-only updates so DOI enrichment is consistently included.
  * Prevents duplicate DOI links from being added when one already exists.

* **Tests**
  * Added coverage for DOI matching, missing-data handling, batch enrichment, and report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->